### PR TITLE
Update SA-12 Sabot jamming degradation ranges

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,10 +304,10 @@
                     'ea-30g': { // Jammed by EA-30G Fowler
                         degradedRings: [
                             { type: 'sensor', rangeNm: 150, name: 'Sensor (Non-Manoeuvring)' },
-                            { type: 'sensor', rangeNm: 50, name: 'Sensor (Fighter)' },
-                            { type: 'sensor', rangeNm: 20, name: 'Sensor (Cruise Missile)' },
-                            // Hypersonic detection is completely degraded
-                            { type: 'weapon', rangeNm: 100, name: 'Weapon Range' } // Weapon range is unaffected
+                            { type: 'sensor', rangeNm: 50,  name: 'Sensor (Fighter)' },
+                            { type: 'sensor', rangeNm: 30,  name: 'Sensor (Cruise Missile)' },
+                            { type: 'sensor', rangeNm: 20,  name: 'Sensor (Hypersonic)' },
+                            { type: 'weapon', rangeNm: 100, name: 'Weapon Range' }
                         ]
                     }
                 }


### PR DESCRIPTION
## Summary
- include cruise missile and hypersonic degraded sensor ranges for SA-12 Sabot jamming effects
- remove outdated comment about hypersonic detection being completely degraded

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c19f70d608328818b643b789398dd