### PR TITLE
Rename EA-30G asset to Flowler

### DIFF
--- a/index.html
+++ b/index.html
@@ -301,7 +301,7 @@
                     { type: 'weapon', rangeNm: 100, name: 'Weapon Range' }
                 ],
                 jammingEffects: {
-                    'ea-30g': { // Jammed by EA-30G Fowler
+                    'ea-30g': { // Jammed by EA-30G Flowler
                         degradedRings: [
                             { type: 'sensor', rangeNm: 150, name: 'Sensor (Non-Manoeuvring)' },
                             { type: 'sensor', rangeNm: 50, name: 'Sensor (Fighter)' },
@@ -352,9 +352,9 @@
                     { type: 'movement', rangeNm: 3000, name: 'Travel Radius' }
                 ]
             },
-            'ea-30g': { 
-                name: 'EA-30G Fowler', 
-                shortName: 'EA-30G', 
+            'ea-30g': {
+                name: 'EA-30G Flowler',
+                shortName: 'EA-30G',
                 force: 'blue', 
                 category: 'air', 
                 platformType: 'air', 


### PR DESCRIPTION
## Summary
- rename EA-30G Fowler to EA-30G Flowler in asset list
- keep jamming references using key `ea-30g`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c19fbc4bc83289f1abee752bacdfe