### PR TITLE
feat: display sensor detections

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,7 +195,10 @@
                     <button id="clear-btn" class="flex-1 px-3 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500">Clear All</button>
                 </div>
             </div>
-            
+
+            <!-- Detection Panel -->
+            <ul id="detection-panel" class="absolute top-4 right-4 z-[1000] bg-white/90 p-2 rounded-lg shadow-lg text-gray-800 text-sm space-y-1"></ul>
+
             <!-- NEW: Targeting Control Panel -->
             <div id="targeting-panel" class="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-full w-full max-w-4xl bg-gray-800/90 text-white p-4 rounded-t-lg shadow-2xl z-[1000]">
                 <div id="targeting-panel-content" class="text-center"></div>
@@ -1213,6 +1216,43 @@
                             sensor.detectedTargets.push({ unitId: target.unitId, classification });
                         });
                 });
+            });
+
+            refreshDetectionPanel();
+        }
+
+        function refreshDetectionPanel() {
+            const panel = document.getElementById('detection-panel');
+            if (!panel) return;
+            panel.innerHTML = '';
+
+            const detections = [];
+            activeMapUnits.forEach(unit => {
+                if (unit.detectedTargets && unit.detectedTargets.length > 0) {
+                    unit.detectedTargets.forEach(dt => {
+                        detections.push({
+                            sensorId: unit.unitId,
+                            targetId: dt.unitId,
+                            classification: dt.classification
+                        });
+                    });
+                }
+            });
+
+            detections.forEach(({ sensorId, targetId, classification }) => {
+                const sensorUnit = activeMapUnits.get(sensorId);
+                const targetUnit = activeMapUnits.get(targetId);
+                const sensorName = sensorUnit?.unitData?.name || sensorId;
+                const targetName = targetUnit?.unitData?.name || targetId;
+                const classLabel = classification
+                    ? classification.split(' ').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
+                    : '';
+
+                const li = document.createElement('li');
+                li.textContent = `${sensorName} ➜ ${targetName}${classLabel ? ` (${classLabel})` : ''}`;
+                li.dataset.sensor = sensorId;
+                li.dataset.target = targetId;
+                panel.appendChild(li);
             });
         }
 


### PR DESCRIPTION
## Summary
- add detection panel to map UI
- update detection logic to refresh panel after computing targets
- list sensor-to-target relationships with classification

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d43f119e083289627e1a027aebe0b