### PR TITLE
Update E-17A classification

### DIFF
--- a/index.html
+++ b/index.html
@@ -438,7 +438,7 @@
                 force: 'blue',
                 category: 'air',
                 platformType: 'air',
-                classification: 'large-ac',
+                classification: 'non-manoeuvring',
                 iconUrl: 'https://cdn-icons-png.flaticon.com/512/7893/7893970.png',
                 speedKph: 617, // Mach 0.5
                 hardpoints: 0,


### PR DESCRIPTION
## Summary
- update E-17A Wedge-Snail classification to non-manoeuvring

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open 'package.json')

------
https://chatgpt.com/codex/tasks/task_e_689d48f13a04832891a6ae5af646d550