### PR TITLE
Fix SA-12 Sabot classification and sensor targeting

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,7 +315,7 @@
                 shortName: 'SA-12',
                 force: 'red',
                 category: 'weapons',
-                classification: 'land',
+                classification: 'cruise-missile',
                 iconUrl: 'https://cdn-icons-png.flaticon.com/512/7165/7165074.png',
                 ammo: 8,
                 movable: true,
@@ -324,7 +324,7 @@
                 reloadTimeHours: 6,
                 weaponSpeedMach: 1,
                 rangeRings: [
-                    { type: 'sensor', rangeNm: 300, name: 'Sensor (Non-Manoeuvring)', targetClass: 'large-ac' },
+                    { type: 'sensor', rangeNm: 300, name: 'Sensor (Non-Manoeuvring)', targetClass: 'non-manoeuvring' },
                     { type: 'sensor', rangeNm: 140, name: 'Sensor (Fighter)',       targetClass: 'fighter' },
                     { type: 'sensor', rangeNm: 60,  name: 'Sensor (Cruise Missile)', targetClass: 'cruise-missile' },
                     { type: 'sensor', rangeNm: 20,  name: 'Sensor (Hypersonic)',     targetClass: 'hypersonic' },
@@ -333,7 +333,7 @@
                 jammingEffects: {
                     'ea-30g': { // Jammed by EA-30G Flowler
                         degradedRings: [
-                            { type: 'sensor', rangeNm: 150, name: 'Sensor (Non-Manoeuvring)', targetClass: 'large-ac' },
+                            { type: 'sensor', rangeNm: 150, name: 'Sensor (Non-Manoeuvring)', targetClass: 'non-manoeuvring' },
                             { type: 'sensor', rangeNm: 50,  name: 'Sensor (Fighter)',       targetClass: 'fighter' },
                             { type: 'sensor', rangeNm: 30,  name: 'Sensor (Cruise Missile)', targetClass: 'cruise-missile' },
                             { type: 'sensor', rangeNm: 20,  name: 'Sensor (Hypersonic)',     targetClass: 'hypersonic' },


### PR DESCRIPTION
## Summary
- classify SA-12 Sabot as a cruise missile
- retarget 'Sensor (Non-Manoeuvring)' rings to 'non-manoeuvring' targets, including jamming degradation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d48f1cb948328a7ae5d2bd1b09cd4