### PR TITLE
Remove duplicate detection panel element

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,16 +196,13 @@
                 </div>
             </div>
 
-            <!-- Detection Panel -->
-            <div id="detection-panel" class="absolute top-4 right-4 z-[1000] w-64 max-h-96 overflow-y-auto bg-white shadow rounded p-2 space-y-1"></div>
-
             <!-- NEW: Targeting Control Panel -->
             <div id="targeting-panel" class="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-full w-full max-w-4xl bg-gray-800/90 text-white p-4 rounded-t-lg shadow-2xl z-[1000]">
                 <div id="targeting-panel-content" class="text-center"></div>
             </div>
 
             <!-- Detection Results Panel -->
-            <div id="detection-panel" class="absolute top-4 right-4 z-[1000] bg-gray-800/90 text-white p-2 rounded shadow-lg max-h-60 overflow-y-auto"></div>
+            <div id="detection-panel" class="absolute top-4 right-4 z-[1000] w-64 bg-gray-800/90 text-white p-2 rounded shadow-lg max-h-60 overflow-y-auto space-y-1"></div>
         </div>
 
         <!-- Right Hand Menu -->


### PR DESCRIPTION
## Summary
- remove redundant `detection-panel` div and retain styled results panel
- consolidate styles into surviving detection panel

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_689d4bbf856483289a0d7e26751f244c