### PR TITLE
feat: add responsive layout and theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-AU">
+<html lang="en-AU" data-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -10,8 +10,14 @@
       integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
       crossorigin=""/>
 
-    <!-- Tailwind CSS for overall page styling -->
+    <!-- Tailwind CSS with DaisyUI component library -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        plugins: [daisyui],
+      }
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/daisyui@4.7.2/dist/full.js"></script>
 
     <!-- Google Fonts: Inter -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -174,42 +180,43 @@
         .bg-grey-100 { background-color: #f3f4f6; } /* Tailwind's gray-100 */
     </style>
 </head>
-<body class="bg-grey-100">
+<body class="bg-base-200">
 
     <div class="flex h-screen">
         <!-- Map Container -->
         <div id="map-container" class="relative flex-grow h-full">
             <div id="map"></div>
-            <!-- Simulation Controls -->
-            <div class="absolute top-4 left-4 z-[1000] bg-white p-2 rounded-lg shadow-lg flex flex-col space-y-2">
-                <div class="flex">
-                    <button id="toggle-rings-btn" class="flex-1 px-3 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Hide Range Rings</button>
-                </div>
-                <div class="flex space-x-2">
-                    <button id="targeting-btn" class="flex-1 px-3 py-2 text-sm font-medium text-white bg-gray-600 rounded-md hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">Targeting Mode</button>
-                    <button id="launch-btn" class="flex-1 px-3 py-2 text-sm font-medium text-white bg-green-600 rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">Launch Missiles</button>
-                </div>
-                <div class="flex space-x-2">
-                    <button id="save-btn" class="flex-1 px-3 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">Save Scene</button>
-                    <button id="reset-btn" class="flex-1 px-3 py-2 text-sm font-medium text-white bg-orange-500 rounded-md hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-400">Reset Scene</button>
-                    <button id="clear-btn" class="flex-1 px-3 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500">Clear All</button>
-                </div>
-            </div>
+              <!-- Simulation Controls -->
+              <div class="absolute top-4 left-4 z-[1000] bg-base-100 text-base-content p-2 sm:p-4 rounded-lg shadow-lg flex flex-col space-y-2 w-48 sm:w-60">
+                  <div class="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2">
+                      <button id="theme-toggle" class="btn btn-secondary btn-sm w-full">Dark Mode</button>
+                  </div>
+                  <div class="flex">
+                      <button id="toggle-rings-btn" class="flex-1 px-3 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Hide Range Rings</button>
+                  </div>
+                  <div class="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2">
+                      <button id="targeting-btn" class="flex-1 px-3 py-2 text-sm font-medium text-white bg-gray-600 rounded-md hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">Targeting Mode</button>
+                      <button id="launch-btn" class="flex-1 px-3 py-2 text-sm font-medium text-white bg-green-600 rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">Launch Missiles</button>
+                  </div>
+                  <div class="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2">
+                      <button id="save-btn" class="flex-1 px-3 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">Save Scene</button>
+                      <button id="reset-btn" class="flex-1 px-3 py-2 text-sm font-medium text-white bg-orange-500 rounded-md hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-400">Reset Scene</button>
+                      <button id="clear-btn" class="flex-1 px-3 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500">Clear All</button>
+                  </div>
+              </div>
 
             <!-- Detection Panel -->
-            <div id="detection-panel" class="absolute top-4 right-4 z-[1000] w-64 max-h-96 overflow-y-auto bg-white shadow rounded p-2 space-y-1"></div>
+              <div id="detection-panel" class="absolute top-4 right-4 z-[1000] w-48 sm:w-64 max-h-96 overflow-y-auto bg-base-100 text-base-content shadow rounded p-2 space-y-1"></div>
 
             <!-- NEW: Targeting Control Panel -->
             <div id="targeting-panel" class="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-full w-full max-w-4xl bg-gray-800/90 text-white p-4 rounded-t-lg shadow-2xl z-[1000]">
                 <div id="targeting-panel-content" class="text-center"></div>
             </div>
 
-            <!-- Detection Results Panel -->
-            <div id="detection-panel" class="absolute top-4 right-4 z-[1000] bg-gray-800/90 text-white p-2 rounded shadow-lg max-h-60 overflow-y-auto"></div>
         </div>
 
         <!-- Right Hand Menu -->
-        <div class="w-80 h-full bg-white shadow-lg overflow-y-auto p-4 border-l border-gray-200 flex flex-col">
+          <div class="w-80 h-full bg-base-100 text-base-content shadow-lg overflow-y-auto p-4 border-l border-gray-200 flex flex-col">
             <h2 class="text-xl font-bold text-gray-800 mb-4 text-center">Entity Library</h2>
             <div id="unit-menu" class="space-y-4 flex-grow">
                 <!-- Menu content will be generated by JavaScript -->
@@ -1715,7 +1722,25 @@
             modal.classList.remove('hidden');
         }
 
-        document.addEventListener('DOMContentLoaded', initializeApp);
+        function initializeTheme() {
+            const root = document.documentElement;
+            const toggle = document.getElementById('theme-toggle');
+            if (!toggle) return;
+            const stored = localStorage.getItem('theme') || 'light';
+            root.setAttribute('data-theme', stored);
+            toggle.textContent = stored === 'dark' ? 'Light Mode' : 'Dark Mode';
+            toggle.addEventListener('click', () => {
+                const current = root.getAttribute('data-theme');
+                const next = current === 'dark' ? 'light' : 'dark';
+                root.setAttribute('data-theme', next);
+                localStorage.setItem('theme', next);
+                toggle.textContent = next === 'dark' ? 'Light Mode' : 'Dark Mode';
+            });
+        }
+        document.addEventListener('DOMContentLoaded', () => {
+            initializeTheme();
+            initializeApp();
+        });
 
     </script>
 </body>


### PR DESCRIPTION
## Summary
- integrate DaisyUI with Tailwind and introduce theme toggle with persistence
- add responsive classes to control buttons and panels for small screens
- enable dynamic light/dark theming across UI panels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d4bdd2f608328827aef86f4ce6a09