### PR TITLE
feat: offload detection to web worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,6 +267,9 @@
         var activeInfoPopup = null;
         var rangeRingsVisible = true;
         var labelingMode = false;
+        // Web worker responsible for heavy detection calculations
+        var detectionWorker = new Worker('js/detectionWorker.js');
+        detectionWorker.onmessage = handleDetectionResults;
 
         // --- VISUAL CONFIGURATION ---
         const ringStyles = {
@@ -1154,73 +1157,28 @@
         }
 
         function updateDetections() {
-            const sensors = Array.from(activeMapUnits.values()).filter(u =>
-                (u.effectiveRangeRings || []).some(r => r.type === 'sensor')
-            );
+            const sensors = [];
+            const units = [];
 
-            sensors.forEach(sensor => {
-                sensor.detectedTargets = sensor.detectedTargets || [];
-                const sensorPos = sensor.marker.getLatLng();
-                const sensorRings = (sensor.effectiveRangeRings || [])
-                    .filter(ring => ring.type === 'sensor')
-                    .sort((a, b) => a.rangeNm - b.rangeNm);
-
-                activeMapUnits.forEach(target => {
-                    if (target.unitData.force === sensor.unitData.force) return;
-                    target.detectedBy = target.detectedBy || [];
-
-                    const distance = sensorPos.distanceTo(target.marker.getLatLng());
-                    const ring = sensorRings.find(r => distance <= r.rangeNm * NM_TO_METERS);
-
-                    const sensorEntryIndex = sensor.detectedTargets.findIndex(dt => dt.instanceId === target.instanceId);
-                    const targetEntryIndex = target.detectedBy.findIndex(db => db.instanceId === sensor.instanceId);
-
-                    if (ring) {
-                        const classification = getRingClassification(ring.name);
-                        if (sensorEntryIndex !== -1 && targetEntryIndex !== -1) {
-                            if (sensor.detectedTargets[sensorEntryIndex].classification !== classification) {
-                                sensor.detectedTargets[sensorEntryIndex].classification = classification;
-                                target.detectedBy[targetEntryIndex].classification = classification;
-                            }
-                        } else {
-                            sensor.detectedTargets.push({ instanceId: target.instanceId, classification });
-                            target.detectedBy.push({ instanceId: sensor.instanceId, classification });
-                        }
-                    } else {
-                        if (sensorEntryIndex !== -1) {
-                            sensor.detectedTargets.splice(sensorEntryIndex, 1);
-                        }
-                        if (targetEntryIndex !== -1) {
-                            target.detectedBy.splice(targetEntryIndex, 1);
-                        }
-                    }
+            activeMapUnits.forEach(unit => {
+                const pos = unit.marker.getLatLng();
+                units.push({
+                    instanceId: unit.instanceId,
+                    force: unit.unitData.force,
+                    position: { lat: pos.lat, lng: pos.lng }
                 });
+
+                if ((unit.effectiveRangeRings || []).some(r => r.type === 'sensor')) {
+                    sensors.push({
+                        instanceId: unit.instanceId,
+                        force: unit.unitData.force,
+                        position: { lat: pos.lat, lng: pos.lng },
+                        effectiveRangeRings: unit.effectiveRangeRings
+                    });
+                }
             });
 
-            const priority = { unknown: 0, suspected: 1, confirmed: 2 };
-            activeMapUnits.forEach(target => {
-                if (!target.detectedBy || target.detectedBy.length === 0) return;
-
-                const aggregated = {};
-                target.detectedBy.forEach(entry => {
-                    const existing = aggregated[entry.instanceId];
-                    if (!existing || (priority[entry.classification] || 0) > (priority[existing.classification] || 0)) {
-                        aggregated[entry.instanceId] = { instanceId: entry.instanceId, classification: entry.classification };
-                    }
-                });
-                target.detectedBy = Object.values(aggregated);
-
-                Object.values(aggregated).forEach(({ instanceId: sensorInstanceId, classification }) => {
-                    sensors
-                        .filter(s => s.instanceId === sensorInstanceId)
-                        .forEach(sensor => {
-                            sensor.detectedTargets = sensor.detectedTargets || [];
-                            sensor.detectedTargets = sensor.detectedTargets.filter(dt => dt.instanceId !== target.instanceId);
-                            sensor.detectedTargets.push({ instanceId: target.instanceId, classification });
-                        });
-                });
-            });
-            refreshDetectionPanel();
+            detectionWorker.postMessage({ sensors, units });
         }
 
         function flyToUnit(instanceId, zoom = 7) {
@@ -1238,9 +1196,11 @@
             const panel = document.getElementById('detection-panel');
             if (!panel) return;
             panel.innerHTML = '';
+            let hasDetections = false;
 
             activeMapUnits.forEach(sensor => {
                 if (!sensor.detectedTargets || sensor.detectedTargets.length === 0) return;
+                hasDetections = true;
 
                 const sensorDiv = document.createElement('div');
                 const sensorName = document.createElement('span');
@@ -1268,6 +1228,36 @@
                 sensorDiv.appendChild(list);
                 panel.appendChild(sensorDiv);
             });
+
+            if (!hasDetections) {
+                panel.innerHTML = '<p class="text-xs italic">No detections</p>';
+            }
+        }
+
+        function handleDetectionResults(event) {
+            const { sensors, targets } = event.data;
+
+            sensors.forEach(s => {
+                const sensorUnit = activeMapUnits.get(s.instanceId);
+                if (!sensorUnit) return;
+                sensorUnit.detectedTargets = s.detectedTargets || [];
+                const el = sensorUnit.marker.getElement();
+                if (el) {
+                    el.style.filter = s.detectedTargets && s.detectedTargets.length > 0 ? 'drop-shadow(0 0 4px cyan)' : '';
+                }
+            });
+
+            targets.forEach(t => {
+                const targetUnit = activeMapUnits.get(t.instanceId);
+                if (!targetUnit) return;
+                targetUnit.detectedBy = t.detectedBy || [];
+                const el = targetUnit.marker.getElement();
+                if (el) {
+                    el.style.filter = t.detectedBy && t.detectedBy.length > 0 ? 'drop-shadow(0 0 4px yellow)' : '';
+                }
+            });
+
+            refreshDetectionPanel();
         }
 
         function getPointAtDistance(start, end, distance) {

--- a/js/detectionWorker.js
+++ b/js/detectionWorker.js
@@ -1,0 +1,69 @@
+const NM_TO_METERS = 1852;
+const classificationPriority = { unknown: 0, suspect: 1, confirmed: 2 };
+
+function getRingClassification(name) {
+  const match = name.match(/\(([^)]+)\)/);
+  const raw = (match ? match[1] : name).trim().toLowerCase();
+  const mapping = {
+    'lrg ac': 'large ac',
+    'unk': 'unknown',
+    'unknown': 'unknown',
+    'sus': 'suspect',
+    'suspect': 'suspect',
+    'conf': 'confirmed',
+    'confirmed': 'confirmed'
+  };
+  const classification = mapping[raw] || raw;
+  return classificationPriority[classification] !== undefined ? classification : 'unknown';
+}
+
+function haversine(p1, p2) {
+  const R = 6371000; // metres
+  const toRad = deg => deg * Math.PI / 180;
+  const dLat = toRad(p2.lat - p1.lat);
+  const dLon = toRad(p2.lng - p1.lng);
+  const lat1 = toRad(p1.lat);
+  const lat2 = toRad(p2.lat);
+
+  const a = Math.sin(dLat/2) * Math.sin(dLat/2) +
+            Math.cos(lat1) * Math.cos(lat2) *
+            Math.sin(dLon/2) * Math.sin(dLon/2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+  return R * c;
+}
+
+self.onmessage = function(e) {
+  const { sensors = [], units = [] } = e.data;
+  const sensorResults = [];
+  const targetMap = new Map();
+
+  sensors.forEach(sensor => {
+    const sensorRings = (sensor.effectiveRangeRings || [])
+      .filter(r => r.type === 'sensor')
+      .sort((a,b) => a.rangeNm - b.rangeNm);
+    const detectedTargets = [];
+
+    units.forEach(target => {
+      if (target.force === sensor.force) return;
+      const distance = haversine(sensor.position, target.position);
+      const ring = sensorRings.find(r => distance <= r.rangeNm * NM_TO_METERS);
+      if (ring) {
+        const classification = getRingClassification(ring.name);
+        detectedTargets.push({ instanceId: target.instanceId, classification });
+
+        const existing = targetMap.get(target.instanceId) || [];
+        existing.push({ instanceId: sensor.instanceId, classification });
+        targetMap.set(target.instanceId, existing);
+      }
+    });
+
+    sensorResults.push({ instanceId: sensor.instanceId, detectedTargets });
+  });
+
+  const targetResults = [];
+  targetMap.forEach((detectedBy, instanceId) => {
+    targetResults.push({ instanceId, detectedBy });
+  });
+
+  self.postMessage({ type: 'detectionResults', sensors: sensorResults, targets: targetResults });
+};


### PR DESCRIPTION
## Summary
- move detection processing into `js/detectionWorker.js`
- push unit state to worker and handle results on the main thread
- refresh detection panel and highlight units when detections change

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d4bdf57208328a79ddcfb5de461ad