### PR TITLE
Handle measuring in marker click handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -682,8 +682,12 @@
             });
 
             marker.on('click', (e) => {
+                if (measuring) {
+                    map.fire('click', { latlng: marker.getLatLng() });
+                    return;
+                }
                 L.DomEvent.stopPropagation(e);
-                
+
                 if (activeAction.type === 'targeting') {
                     if (activeAction.armedWeapon) {
                         setTarget(unitObject);


### PR DESCRIPTION
## Summary
- Redirect marker clicks to map when measuring and stop event handling

## Testing
- `npm test` *(fails: ENOENT - package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d5a3cafd483289b44bec4125300dc