### PR TITLE
Keep map measurements visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -1624,10 +1624,6 @@
                             interactive: false,
                             icon: L.divIcon({ className: 'distance-label', html: `${(distance / 1000).toFixed(2)} km` })
                         }).addTo(map);
-                        setTimeout(() => {
-                            if (measureLine) { measureLine.remove(); measureLine = null; }
-                            if (measureLabel) { measureLabel.remove(); measureLabel = null; }
-                        }, 5000);
                         measuring = false;
                         measureStart = null;
                         measureBtn.textContent = 'Measure';


### PR DESCRIPTION
## Summary
- Remove timeout that cleared measurement lines and labels after 5s so measurement results stay on the map

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d5bd9952c8328add704606ce94cf7