### PR TITLE
Display km and nm distance in measurement tooltip

### DIFF
--- a/index.html
+++ b/index.html
@@ -1619,10 +1619,12 @@
                         const end = e.latlng;
                         measureLine = L.polyline([measureStart, end], { color: 'yellow', weight: 2, dashArray: '4,4' }).addTo(map);
                         const distance = map.distance(measureStart, end);
+                        const distanceKm = distance / 1000;
+                        const distanceNm = distance / 1852;
                         const mid = L.latLng((measureStart.lat + end.lat) / 2, (measureStart.lng + end.lng) / 2);
                         measureLabel = L.marker(mid, {
                             interactive: false,
-                            icon: L.divIcon({ className: 'distance-label', html: `${(distance / 1000).toFixed(2)} km` })
+                            icon: L.divIcon({ className: 'distance-label', html: `${distanceKm.toFixed(2)} km / ${distanceNm.toFixed(2)} nm` })
                         }).addTo(map);
                         setTimeout(() => {
                             if (measureLine) { measureLine.remove(); measureLine = null; }


### PR DESCRIPTION
## Summary
- Compute distance in kilometers and nautical miles when measuring on map
- Show both distance units in the measurement label

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689d5bd34c188328a2390ece8337f788