### PR TITLE
feat: add collapsible detection sensor panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,6 +297,7 @@
         let measureStart = null;
         let measureLine = null;
         let measureLabel = null;
+        const collapsedSensors = new Set();
 
         function clearMeasure() {
             if (measureLine) {
@@ -1332,13 +1333,40 @@
 
             sensors.forEach(sensor => {
                 const sensorDiv = document.createElement('div');
+                sensorDiv.className = 'mb-2';
+
+                const header = document.createElement('div');
+                header.className = 'flex items-center';
+
+                const list = document.createElement('ul');
+                const isCollapsed = collapsedSensors.has(sensor.instanceId);
+                if (isCollapsed) list.style.display = 'none';
+
+                const toggleBtn = document.createElement('button');
+                toggleBtn.textContent = isCollapsed ? '▸' : '▾';
+                toggleBtn.className = 'mr-2 text-gray-500 hover:text-gray-700 focus:outline-none';
+                toggleBtn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    if (collapsedSensors.has(sensor.instanceId)) {
+                        collapsedSensors.delete(sensor.instanceId);
+                        list.style.display = '';
+                        toggleBtn.textContent = '▾';
+                    } else {
+                        collapsedSensors.add(sensor.instanceId);
+                        list.style.display = 'none';
+                        toggleBtn.textContent = '▸';
+                    }
+                });
+
                 const sensorName = document.createElement('span');
                 sensorName.textContent = sensor.unitData.name;
                 sensorName.className = 'cursor-pointer underline text-blue-400';
                 sensorName.addEventListener('click', () => flyToUnit(sensor.instanceId));
-                sensorDiv.appendChild(sensorName);
 
-                const list = document.createElement('ul');
+                header.appendChild(toggleBtn);
+                header.appendChild(sensorName);
+                sensorDiv.appendChild(header);
+
                 activeMapUnits.forEach(target => {
                     if (target.unitData.force === sensor.unitData.force) return;
 


### PR DESCRIPTION
## Summary
- wrap each sensor section in a collapsible panel with a toggle button
- maintain collapsed state across refreshes using a Set keyed by sensor id
- preserve sensor name click-to-fly behavior and style toggle with Tailwind classes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d5f51bb90832887d703997948eb2c