### PR TITLE
Fix detection panel toggle state persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,6 +298,7 @@
         let measureLine = null;
         let measureLabel = null;
         const collapsedSensors = new Set();
+        let lastDetectionSignature = '';
 
         function clearMeasure() {
             if (measureLine) {
@@ -1308,7 +1309,18 @@
                 }
             });
 
-            refreshDetectionPanel();
+            const newSignature = JSON.stringify(
+                sensors.map(sensor => ({
+                    id: sensor.instanceId,
+                    targets: (sensor.detectedTargets || [])
+                        .map(dt => dt.instanceId)
+                        .sort(),
+                }))
+            );
+            if (newSignature !== lastDetectionSignature) {
+                lastDetectionSignature = newSignature;
+                refreshDetectionPanel();
+            }
         }
 
         function flyToUnit(instanceId, zoom = 7) {
@@ -1343,6 +1355,7 @@
                 if (isCollapsed) list.style.display = 'none';
 
                 const toggleBtn = document.createElement('button');
+                toggleBtn.type = 'button';
                 toggleBtn.textContent = isCollapsed ? '▸' : '▾';
                 toggleBtn.className = 'mr-2 text-gray-500 hover:text-gray-700 focus:outline-none';
                 toggleBtn.addEventListener('click', (e) => {
@@ -1350,12 +1363,11 @@
                     if (collapsedSensors.has(sensor.instanceId)) {
                         collapsedSensors.delete(sensor.instanceId);
                         list.style.display = '';
-                        toggleBtn.textContent = '▾';
                     } else {
                         collapsedSensors.add(sensor.instanceId);
                         list.style.display = 'none';
-                        toggleBtn.textContent = '▸';
                     }
+                    toggleBtn.textContent = collapsedSensors.has(sensor.instanceId) ? '▸' : '▾';
                 });
 
                 const sensorName = document.createElement('span');


### PR DESCRIPTION
## Summary
- Prevent detection panel toggle button from submitting forms by setting type="button"
- Preserve collapsed sensor state across updates and only refresh panel when detection data changes
- Update toggle click handler to sync collapsed state and button glyph

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d614004908328b0ca9a3706b8253a